### PR TITLE
Support functions in title objects

### DIFF
--- a/.versions
+++ b/.versions
@@ -21,7 +21,7 @@ iron:url@1.0.7
 jquery@1.11.3_2
 json@1.0.3
 logging@1.0.7
-lookback:seo@1.0.0
+lookback:seo@1.0.1
 meteor@1.1.5
 minifiers@1.1.4
 minimongo@1.0.7

--- a/test-app/test-app.coffee
+++ b/test-app/test-app.coffee
@@ -42,7 +42,7 @@ if Meteor.isClient
   )
 
   Template.home.created = ->
-    Session.setDefault 'title', 'Title session'
+    Session.setDefault 'title', 'Session title'
     Session.setDefault 'dynamic', 'DYNAMIC VALUE'
 
   Router.route 'home',
@@ -75,6 +75,18 @@ if Meteor.isClient
 
     data: ->
       page: 'Object'
+
+  Router.route 'objectFunctions',
+    template: 'home'
+    seo:
+      title:
+        text: ->
+          'Object function title'
+        suffix: ->
+          'Suffix'
+
+    data: ->
+      page: 'Object-Functions'
 
   Router.route 'no-suffix',
     template: 'home'

--- a/test-app/test-app.html
+++ b/test-app/test-app.html
@@ -15,6 +15,7 @@
     <li><a href="{{pathFor 'session'}}">Session</a></li>
     <li><a href="{{pathFor 'function'}}">Function</a></li>
     <li><a href="{{pathFor 'object'}}">Object</a></li>
+    <li><a href="{{pathFor 'objectFunctions'}}">Object-Functions</a></li>
     <li><a href="{{pathFor 'props'}}">Advanced props</a></li>
     <li><a href="{{pathFor 'data'}}">Data</a></li>
   </ul>

--- a/test-app/tests/mocha/client/RouterSpec.coffee
+++ b/test-app/tests/mocha/client/RouterSpec.coffee
@@ -56,6 +56,14 @@ MochaWeb?.testOnly ->
           done()
         , 10
 
+      it 'should be able to be set from an object with functions', (done) ->
+        Router.go 'objectFunctions'
+
+        Meteor.setTimeout ->
+          document.title.should.equal 'Object function title · Suffix'
+          done()
+        , 10
+
       it 'should be able have no suffix', (done) ->
         Router.go 'no-suffix'
 


### PR DESCRIPTION
Targets https://github.com/lookback/meteor-seo/issues/2.

Add support for constructs like:

``` coffeescript
seo: 
   title:
      text: ->
         'Some title'
      suffix: ->
         'A suffix'
```
