### PR TITLE
twitter metatag change from property to name

### DIFF
--- a/lib/router.coffee
+++ b/lib/router.coffee
@@ -66,7 +66,7 @@ Formatter = (opts) ->
 # Create formatters for OpenGraph, Twitter and regular meta tags.
 OpenGraphFormatter = Formatter name: 'property', prefix: 'og'
 
-TwitterFormatter = Formatter name: 'property', prefix: 'twitter'
+TwitterFormatter = Formatter name: 'name', prefix: 'twitter'
 
 MetaFormatter = Formatter name: 'name'
 


### PR DESCRIPTION
In the metatags for twitter
ie. 

```html
<meta name="twitter:card" content="summary" />
<meta name="twitter:site" content="@flickr" />
<meta name="twitter:title" content="Small Island Developing States Photo Submission" />
<meta name="twitter:description" content="View the album on Flickr." />
<meta name="twitter:image" content="https://farm6.staticflickr.com/5510/14338202952_93595258ff_z.jpg" />
```

its 

```html
<meta name="twitter:propertyName" content="your content"/>
```

whereas currently the package generates this:

```html
<meta property="twitter:propertyName" content="your content"/>
```

https://dev.twitter.com/cards/types/summary

so propose to change this