### PR TITLE
Add mongo package dependancy

### DIFF
--- a/package.js
+++ b/package.js
@@ -13,6 +13,7 @@ Package.onUse(function(api) {
   api.imply('yasinuslu:blaze-meta@0.3.1', where);
 
   api.use([
+    'mongo',
     'coffeescript',
     'tracker',
     'underscore',

--- a/package.js
+++ b/package.js
@@ -13,7 +13,6 @@ Package.onUse(function(api) {
   api.imply('yasinuslu:blaze-meta@0.3.1', where);
 
   api.use([
-    'mongo',
     'coffeescript',
     'tracker',
     'underscore',

--- a/test-app/.meteor/packages
+++ b/test-app/.meteor/packages
@@ -5,6 +5,7 @@
 # but you can also edit it by hand.
 
 meteor-platform
+mongo
 iron:router
 lookback:seo
 coffeescript


### PR DESCRIPTION
Since I’ve updated meteor to v1.4.3.1, 
I got an error in the client : 

```
Uncaught ReferenceError: Mongo is not defined
    at lookback_seo.js?hash=0bf747b…:281
    at lookback_seo.js?hash=0bf747b…:473
    at lookback_seo.js?hash=0bf747b…:480
(anonymous) @ lookback_seo.js?hash=0bf747b…:281
(anonymous) @ lookback_seo.js?hash=0bf747b…:473
(anonymous) @ lookback_seo.js?hash=0bf747b…:480
```

This pull request fix it